### PR TITLE
Add channel title and thumbnail data to normalizeContentNode.

### DIFF
--- a/kolibri/core/content/utils/search.py
+++ b/kolibri/core/content/utils/search.py
@@ -49,7 +49,7 @@ def _get_available_channels(base_queryset):
             id__in=base_queryset.values_list("channel_id", flat=True).distinct()
         )
         .order_by("order")
-        .values("id", "name")
+        .values("id", "name", "thumbnail")
     )
 
 

--- a/kolibri/plugins/learn/assets/src/modules/coreLearn/utils.js
+++ b/kolibri/plugins/learn/assets/src/modules/coreLearn/utils.js
@@ -3,9 +3,16 @@ import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
 import tail from 'lodash/tail';
+import plugin_data from 'plugin_data';
+
+const channels = {};
+for (let channel of plugin_data.channels) {
+  channels[channel.id] = channel;
+}
 
 // adds progress, thumbnail, and breadcrumbs. normalizes pk/id and kind
 export function normalizeContentNode(node) {
+  const channel = channels[node.channel_id];
   return {
     ...node,
     kind: node.parent ? node.kind : ContentNodeKinds.CHANNEL,
@@ -13,6 +20,8 @@ export function normalizeContentNode(node) {
     breadcrumbs: tail(node.ancestors),
     progress: Math.min(node.progress_fraction || 0, 1.0),
     copies_count: node.copies_count,
+    channel_title: channel ? channel.name : '',
+    channel_thumbnail: channel ? channel.thumbnail : null,
   };
 }
 

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -45,7 +45,7 @@
       :key="content.id"
       :contentNode="content"
       :channelThumbnail="content.channel_thumbnail"
-      :channelTitle="content.channel_thumbnail"
+      :channelTitle="content.channel_title"
       :description="content.description"
       :activityLength="content.activity_length"
       class="grid-item"

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -243,6 +243,7 @@
 
   .channel-logo {
     display: inline-block;
+    height: 28px;
   }
 
   .text {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -197,6 +197,7 @@
   import genContentLink from '../utils/genContentLink';
   import FullScreenSidePanel from '../../../../../core/assets/src/views/FullScreenSidePanel';
   import { PageNames } from '../constants';
+  import { normalizeContentNode } from '../modules/coreLearn/utils';
   import commonLearnStrings from './commonLearnStrings';
   import ChannelCardGroupGrid from './ChannelCardGroupGrid';
   import HybridLearningCardGrid from './HybridLearningCardGrid';
@@ -392,7 +393,7 @@
             getParams.keywords = this.searchTerms.keywords;
           }
           ContentNodeResource.fetchCollection({ getParams }).then(data => {
-            this.results = data.results;
+            this.results = data.results.map(normalizeContentNode);
             this.more = data.more;
             this.labels = data.labels;
             this.searchLoading = false;
@@ -408,7 +409,7 @@
         if (this.displayingSearchResults && this.more && !this.moreLoading) {
           this.moreLoading = true;
           ContentNodeResource.fetchCollection({ getParams: this.more }).then(data => {
-            this.results.push(...data.results);
+            this.results.push(...data.results.map(normalizeContentNode));
             this.more = data.more;
             this.labels = data.labels;
             this.moreLoading = false;


### PR DESCRIPTION
### Summary
* Add thumbnails to bootstrapped channels data
* Add channel title and thumbnail to normalize content node

### Reviewer guidance
* Do channel thumbnails now show up on hybrid learning cards?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
